### PR TITLE
[2911][FIX] account_move_solomon_csv: amount consistency

### DIFF
--- a/account_move_solomon_csv/__manifest__.py
+++ b/account_move_solomon_csv/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Move Solomon CSV",
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.0.2",
     "category": "Accounting",
     "author": "Quartile Limited",
     "website": "https://www.quartile.co",

--- a/account_move_solomon_csv/i18n/ja.po
+++ b/account_move_solomon_csv/i18n/ja.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-19 14:42+0000\n"
-"PO-Revision-Date: 2023-01-19 14:42+0000\n"
+"POT-Creation-Date: 2023-02-14 14:19+0000\n"
+"PO-Revision-Date: 2023-02-14 14:19+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -105,6 +105,13 @@ msgstr ""
 #: model:ir.model.fields,help:account_move_solomon_csv.field_res_company__solomon_company_code
 msgid "The set value will be used in Solomon data export."
 msgstr "設定値はSolomonデータ出力に使用されます。"
+
+#. module: account_move_solomon_csv
+#. odoo-python
+#: code:addons/account_move_solomon_csv/report/report_account_move_solomon_csv.py:0
+#, python-format
+msgid "There is an item with multiple analytic plans: %s"
+msgstr "複数の分析プランが紐づいた仕訳項目があります: %s"
 
 #. module: account_move_solomon_csv
 #: model:ir.model.fields,help:account_move_solomon_csv.field_account_analytic_line__plan_type


### PR DESCRIPTION
[2911](https://www.quartile.co/web#view_type=form&model=project.task&id=2911&active_id=2911&menu_id=)

Before this fix, there were cases where debit and credit balances did not match when there were multiple analytic accounts from the same analytic plan assigned to a move line, due to rounding.

This commit fixes the issue by identifying the rounding difference and applying it to the last row of the move line.
